### PR TITLE
updated react setServerError to show 401 unverified errors in the app

### DIFF
--- a/client/src/components/views/ConfirmPage.jsx
+++ b/client/src/components/views/ConfirmPage.jsx
@@ -12,7 +12,7 @@ export default function ConfirmPage() {
 
   function doSubmit() {
     dispatch(attemptGetConfirmation(token)).catch((error) => {
-      if (error.response && error.response.status === 400) {
+      if (error.response) {
         setServerError(error.response.data.message);
       }
     });

--- a/client/src/components/views/Login.jsx
+++ b/client/src/components/views/Login.jsx
@@ -25,11 +25,7 @@ export default function Login() {
   const onSubmit = (values) => {
     dispatch(attemptLogin(values)).catch((error) => {
       if(error.response) {
-        if(error.response.status === 400 || error.response.status === 401) {
-          setServerError(error.response.data.message);
-        } else {
-          return
-        }
+        setServerError(error.response.data.message);
       }
     });
   };

--- a/client/src/components/views/Login.jsx
+++ b/client/src/components/views/Login.jsx
@@ -24,8 +24,12 @@ export default function Login() {
 
   const onSubmit = (values) => {
     dispatch(attemptLogin(values)).catch((error) => {
-      if (error.response && error.response.status === 400) {
-        setServerError(error.response.data.message);
+      if(error.response) {
+        if(error.response.status === 400 || error.response.status === 401) {
+          setServerError(error.response.data.message);
+        } else {
+          return
+        }
       }
     });
   };

--- a/client/src/components/views/LoginForgot.jsx
+++ b/client/src/components/views/LoginForgot.jsx
@@ -26,7 +26,7 @@ export default function LoginForgot() {
     dispatch(attemptSendResetPasswordLink(email))
       .then(() => setIsSubmited(true))
       .catch((error) => {
-        if (error.response && error.response.status === 400) {
+        if (error.response) {
           setServerError(error.response.data.message);
         }
       });

--- a/client/src/components/views/LoginResetPassword.jsx
+++ b/client/src/components/views/LoginResetPassword.jsx
@@ -24,7 +24,7 @@ export default function LoginResetPassword() {
   const onSubmit = (values) => {
     const password = values.password;
     dispatch(attemptResetPassword(password, token)).catch((error) => {
-      if (error.response && error.response.status === 400) {
+      if (error.response) {
         setServerError(error.response.data.message);
       }
     });

--- a/client/src/components/views/Register.jsx
+++ b/client/src/components/views/Register.jsx
@@ -47,7 +47,7 @@ export default function Register() {
     dispatch(attemptResendConfirmation(email))
       .then(() => setRegisterStep("reset"))
       .catch((error) => {
-        if (error.response && error.response.status === 400) {
+        if (error.response) {
           setServerError(error.response.data.message);
         }
       });
@@ -55,7 +55,7 @@ export default function Register() {
 
   const onReset = () => {
     dispatch(attemptResetRegister(email)).catch((error) => {
-      if (error.response && error.response.status === 400) {
+      if (error.response) {
         setServerError(error.response.data.message);
       }
     });


### PR DESCRIPTION
Hi, I tested the app, and if a user registers and does not verify the account, and then tries to login, the server throws an 401 unauthorized(401) error,, but the react client does not reflect it 😞... 
But this PR should to fix it 😸, as this adds a check in the login component which listens to 401 errors as well!
Have a great day