### PR TITLE
chore(ci): update upload-artifact action

### DIFF
--- a/.github/workflows/docker-prod-e2e.yml
+++ b/.github/workflows/docker-prod-e2e.yml
@@ -46,7 +46,7 @@ jobs:
         run: yarn test:ci
 
       - name: Upload Playwright Report
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         if: always()
         with:
           name: playwright-report


### PR DESCRIPTION
## Summary
- use actions/upload-artifact v4 for Playwright report upload

## Testing
- `cd e2e && yarn test:ci` *(fails: Executable doesn't exist at /root/.cache/ms-playwright/webkit-2104/pw_run.sh)*

------
https://chatgpt.com/codex/tasks/task_e_6894f3544dac832893c2619981194901