### PR TITLE
docs: document 503 status for user registration

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,3 +81,9 @@ This repository is scanned with snyk and code scanning from github for vulnerabi
 - Use emails for authentication instead of usernames: <https://github.com/flaviuse/mern-authentication/issues/7>
 
 - I added a dependency but my docker container does not found it: <https://medium.com/@semur.nabiev/how-to-make-docker-compose-volumes-ignore-the-node-modules-directory-99f9ec224561> (either install the dependency in the container with the cli or reset the volume).
+
+## API
+
+### POST /user/register
+
+Possible HTTP error codes: 400, 500, 503. The 503 status is returned when the email service is unavailable.

--- a/server/routes/user.routes.ts
+++ b/server/routes/user.routes.ts
@@ -7,7 +7,7 @@ router.get("/", UserController.getUser);
 
 //  Input : username, email, password via body;
 //  HTTP Success : 200 and message.
-//  HTTP Errors : 400,500.
+//  HTTP Errors : 400, 500, 503.
 router.post("/register", UserController.postUser);
 
 // Delete user with the email if is unverified


### PR DESCRIPTION
## Summary
- note that user registration may return HTTP 503
- document 503 response when email service is unavailable

## Testing
- `npm test` (server) *(fails: Missing script "test")*
- `CI=true npm test` (client) *(fails: No tests found)*

------
https://chatgpt.com/codex/tasks/task_e_6894f048a28c8328aeec5c4674002ac0